### PR TITLE
sync website cookies in background - captured from version 1.1.1

### DIFF
--- a/src/ios/CDVWKWebViewFileXhr.m
+++ b/src/ios/CDVWKWebViewFileXhr.m
@@ -71,6 +71,8 @@ NS_ASSUME_NONNULL_BEGIN
 -(void)syncWKtoNSHTTPCookieStore {
     // Sync all cookies from the WKHTTPCookieStore to the NSHTTPCookieStorage..
     // .. to solve make cookies set in the main or IAB webview available for proxy requests
+    @try {
+    dispatch_async(dispatch_get_main_queue(), ^{    // WKWebsiteDataStore must be used from main thread only
     WKWebsiteDataStore* dataStore = [WKWebsiteDataStore defaultDataStore];
     WKHTTPCookieStore* cookieStore = dataStore.httpCookieStore;
     
@@ -84,6 +86,11 @@ NS_ASSUME_NONNULL_BEGIN
             
         }
     }];
+    });
+    }
+    @catch (NSException *exception) {
+    }
+ };
 };
 
 -(void) pluginInitialize {


### PR DESCRIPTION
changes captured from @castana/cordova-plugin-ios-xhr version 1.1.1, ignored spaces & blank lines

(version 1.1.1 seems to switched to DOS line endings, guess someone published it from a PC)

It looks to me like the updates from @castana/cordova-plugin-ios-xhr version 1.1.1 were never pushed to GitHub.

@CASTANA-Solutions I would appreciate it if someone could push the changes for 1.1.1 to GitHub, thanks.