### PR TITLE
Update CDVWKWebViewFileXhr.m

### DIFF
--- a/src/ios/CDVWKWebViewFileXhr.m
+++ b/src/ios/CDVWKWebViewFileXhr.m
@@ -132,9 +132,9 @@ NS_ASSUME_NONNULL_BEGIN
     
     // note:  settings translates all preferences to lower case
     value = [self.commandDelegate.settings cdvwkStringForKey:@"allowuntrustedcerts"];
-    if (value != nil && [value compare:@"on" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+    if (value != nil && [value compare:@"true" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
         _allowsInsecureLoads = YES;
-        NSLog(@"WARNING: NativeXHR is allowing untrusted certificates due to preference AllowUntrustedCerts=on");
+        NSLog(@"WARNING: NativeXHR is allowing untrusted certificates due to preference AllowUntrustedCerts=true");
     }
     
     value = [self.commandDelegate.settings cdvwkStringForKey:@"interceptremoterequests"];


### PR DESCRIPTION
Readme states "true|false" as values for AllowUntrustedCerts, code was checking for "on", and option did never work this way.
To be consisten with other values, change code to compare with "true".